### PR TITLE
Fix white mobs on macOS

### DIFF
--- a/src/cocoa_platform.h
+++ b/src/cocoa_platform.h
@@ -81,7 +81,7 @@ typedef VkResult (APIENTRY *PFN_vkCreateMacOSSurfaceMVK)(VkInstance,const VkMacO
 #define _glfw_dlclose(handle) dlclose(handle)
 #define _glfw_dlsym(handle, name) dlsym(handle, name)
 
-#define _GLFW_EGL_NATIVE_WINDOW  ((EGLNativeWindowType) window->ns.view)
+#define _GLFW_EGL_NATIVE_WINDOW  ((EGLNativeWindowType) window->ns.layer)
 #define _GLFW_EGL_NATIVE_DISPLAY EGL_DEFAULT_DISPLAY
 
 #define _GLFW_PLATFORM_WINDOW_STATE         _GLFWwindowNS  ns

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -914,6 +914,7 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
             // layer required for EGL window surface creation
             [window->ns.view setWantsLayer:YES];
             window->ns.layer = [window->ns.view layer];
+            [window->ns.layer setContentsScale:[window->ns.object backingScaleFactor]];
             if (!_glfwInitEGL())
                 return GLFW_FALSE;
             if (!_glfwCreateContextEGL(window, ctxconfig, fbconfig))

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -864,6 +864,10 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
     _glfwPlatformGetWindowSize(window, &window->ns.width, &window->ns.height);
     _glfwPlatformGetFramebufferSize(window, &window->ns.fbWidth, &window->ns.fbHeight);
 
+    // layer required for EGL window surface creation
+    [window->ns.view setWantsLayer:YES];
+    window->ns.layer = [window->ns.view layer];
+
     return GLFW_TRUE;
 }
 

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -864,10 +864,6 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
     _glfwPlatformGetWindowSize(window, &window->ns.width, &window->ns.height);
     _glfwPlatformGetFramebufferSize(window, &window->ns.fbWidth, &window->ns.fbHeight);
 
-    // layer required for EGL window surface creation
-    [window->ns.view setWantsLayer:YES];
-    window->ns.layer = [window->ns.view layer];
-
     return GLFW_TRUE;
 }
 
@@ -915,6 +911,9 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
         }
         else if (ctxconfig->source == GLFW_EGL_CONTEXT_API)
         {
+            // layer required for EGL window surface creation
+            [window->ns.view setWantsLayer:YES];
+            window->ns.layer = [window->ns.view layer];
             if (!_glfwInitEGL())
                 return GLFW_FALSE;
             if (!_glfwCreateContextEGL(window, ctxconfig, fbconfig))


### PR DESCRIPTION
Call `[window->ns.object setBackgroundColor: NSColor.blackColor];`, fixing the white mob issue on macOS. The issue still occurs when you use f11 for fullscreen (when you use the green button, it is normal.)